### PR TITLE
Removing automatic call to name in errorHandler. Pushing responsibility ...

### DIFF
--- a/qwilr-logger.coffee
+++ b/qwilr-logger.coffee
@@ -89,7 +89,7 @@ module.exports = (options) ->
 		# If we have an error handler function supplied.
 		if options.errorHandler?
 			# Run error handler fn w/ the error + logger name
-			options.errorHandler( logName() + ": " + data )
+			options.errorHandler( data )
 
 	log.success = (data...) ->
 		logBase 'success', colors.green( data )


### PR DESCRIPTION
...to user of qwilr-logger

@dylan-baskind 

This should help with our Sentry errors, and gives more flexibility to those using the logger.
